### PR TITLE
Revert "Update redux-mock-store to version 1.1.2 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-router-redux": "^4.0.2",
     "react-router": "^2.2.4",
     "react": "^0.14.0 || ^15.0.0-0",
-    "redux-mock-store": "1.1.2"
+    "redux-mock-store": "1.0.2"
   },
   "peerDependencies": {
     "immutable": "^3.8.0",


### PR DESCRIPTION
Reverts retaxJS/retax-core#16

`redux-mock-store` type definitions are incomplete and make the build crash.

See https://github.com/arnaudbenard/redux-mock-store/pull/55